### PR TITLE
Add Aizen Privacy Policy document

### DIFF
--- a/aizen_suske_discord_bot_eupp.md
+++ b/aizen_suske_discord_bot_eupp.md
@@ -1,0 +1,90 @@
+# Aizen Privacy Policy
+
+Effective Date: June 11, 2026
+
+## 1. Introduction
+
+This Privacy Policy explains how Aizen, a Discord bot operated by Xieon's Gaming Corner (XGC), collects, accesses, uses, stores, and discloses information when users interact with the bot and its related services on Discord. This policy is intended to describe Aizen's bot-specific data practices, including the handling of Discord message content and attachments when users intentionally invoke bot features.
+
+## 2. Information Aizen Accesses and Collects
+
+Aizen may access or collect the following categories of information when necessary to provide requested bot functionality:
+
+- Discord account and platform identifiers, such as usernames, display names, user IDs, server IDs, channel IDs, role IDs, and message IDs.
+- Bot interaction data, such as slash command use, prefix command use, button interactions, modal submissions, and other direct bot invocations.
+- Message content and attachments only when necessary for user-invoked bot features, such as prefix-based commands or file-processing features submitted in a server channel or direct message.
+- Uploaded files and attachment metadata when users intentionally submit files for analysis, validation, or other bot-supported processing.
+- Limited technical and diagnostic data, such as timestamps, error logs, rate-limit events, and feature usage logs needed to maintain reliability, security, and abuse prevention.
+
+Aizen does not access or use Discord data for advertising, data brokerage, or unrelated profiling of server conversations.
+
+## 3. How Aizen Uses Information
+
+Aizen may use accessed or collected information to:
+
+- Provide bot functionality requested by users.
+- Detect and process prefix-based commands and other direct bot interactions.
+- Retrieve and analyze files intentionally submitted to the bot, including legality checking and similar analysis workflows.
+- Generate bot responses, moderation outcomes, validation results, logs, and user-requested outputs.
+- Maintain service reliability, diagnose errors, prevent abuse, investigate misuse, and enforce applicable rules.
+- Comply with legal obligations and respond to valid legal process.
+
+## 4. Message Content and Attachment Processing
+
+Aizen may access Discord message content and attachments only when necessary for bot features intentionally invoked by users. Examples include:
+
+- Prefix-based text commands, such as commands beginning with a configured bot prefix.
+- Files uploaded directly into a Discord channel or direct message for bot processing.
+- Attachment-based analysis workflows, such as reviewing supported files submitted for validation, legality analysis, or similar user-requested processing.
+
+For example, if a user uploads a supported file such as a `.pk9` file for legality analysis, Aizen may access the message attachment data and the file contents required to complete that requested analysis.
+
+Aizen is not intended to perform general-purpose monitoring of unrelated Discord conversations.
+
+## 5. Data Retention
+
+Aizen retains Discord data only for as long as reasonably necessary to operate the bot, provide requested features, maintain security, investigate abuse, resolve support issues, or comply with legal obligations.
+
+Retention may include the following:
+
+- Raw uploaded files and related attachment data may be stored temporarily for processing, troubleshooting, abuse prevention, or user support, and should be deleted when no longer operationally necessary.
+- Command and interaction logs may be retained for a limited period for debugging, service quality, abuse prevention, and moderation review.
+- Moderation and enforcement records may be retained for a longer period where reasonably necessary to document bans, abuse, fraud, appeals, security incidents, or repeated rule violations.
+- Financial or tax-related records, where applicable, may be retained as required by law.
+
+XGC does not retain Discord data longer than necessary for the operation of Aizen and related compliance, safety, and support purposes.
+
+## 6. Disclosure of Information
+
+Information may be disclosed only in the following circumstances:
+
+- To service providers or infrastructure providers that help operate Aizen, subject to appropriate confidentiality and security controls.
+- To comply with law, regulation, court order, subpoena, or other valid legal process.
+- To protect the rights, safety, security, and integrity of Aizen, XGC, users, or the public.
+- In connection with abuse prevention, fraud investigation, security response, or enforcement of applicable terms and rules.
+
+Aizen does not sell personal information obtained through Discord.
+
+## 7. Security
+
+Reasonable administrative, technical, and organizational safeguards are used to protect information processed by Aizen. However, no system can be guaranteed to be completely secure, and users should understand that transmission and storage of data always involves some risk.
+
+## 8. User Rights and Requests
+
+Depending on applicable law and jurisdiction, users may have rights to request access to, correction of, or deletion of their personal information.
+
+Requests related to Aizen data may be submitted through XGC's official Discord community at [https://discord.gg/xieon](https://discord.gg/xieon) or through any other official contact method published by XGC. Some information may need to be retained where required for legal compliance, dispute resolution, moderation documentation, fraud prevention, or security purposes.
+
+## 9. Donations, Purchases, and Third-Party Payments
+
+If a user makes a donation, purchase, or subscription through a third-party payment provider or platform, payment processing is generally handled by that third party. XGC may retain limited records related to those transactions only as needed for accounting, tax, fraud prevention, legal compliance, customer support, or dispute resolution.
+
+Donation and refund terms, subscription rules, and perk eligibility may be governed by separate policies, terms, or community rules.
+
+## 10. Changes to This Policy
+
+XGC may update this Privacy Policy from time to time. Updated versions may be published through the XGC GitHub repository, Discord community, or another official publication channel. Continued use of Aizen after an updated policy becomes effective constitutes acceptance of the revised policy to the extent permitted by law.
+
+## 11. Contact
+
+Questions or requests regarding this Privacy Policy may be directed through the official XGC Discord community at [https://discord.gg/xieon](https://discord.gg/xieon).


### PR DESCRIPTION
This document outlines the privacy policy for Aizen, a Discord bot, detailing how it collects, uses, and protects user information.